### PR TITLE
Detect 3472 terminal keymap

### DIFF
--- a/oec/__main__.py
+++ b/oec/__main__.py
@@ -31,6 +31,9 @@ def _get_keymap(terminal_id, extended_id):
     if extended_id == 'c1348300':
         keymap = KEYMAP_3483
 
+    if extended_id == 'c1347200':
+        keymap = KEYMAP_3483
+
     return keymap
 
 @contextmanager


### PR DESCRIPTION
The 3472 returns its own terminal type to an extended ID query, but can use the 3483 keymap as is.